### PR TITLE
Make OAuth providers optional

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+
+
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
+{
+	"name": "Node.js",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:20-bookworm",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			"settings": {},
+			"extensions": [
+				"streetsidesoftware.code-spell-checker"
+			]
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [3000],
+
+	// Use 'portsAttributes' to set default properties for specific forwarded ports. 
+	// More info: https://containers.dev/implementors/json_reference/#port-attributes
+	"portsAttributes": {
+		"3000": {
+			"label": "Hello Remote World",
+			"onAutoForward": "notify"
+		}
+	},
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": ""
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/README.md
+++ b/README.md
@@ -72,30 +72,10 @@ To connect to the database and authentication providers, you need a `.env` file 
 
 For authenication to work, at least one set of client ID and client secret needs to be set.
 
-FIXME Add to schema and validation logic.
-
-```
-DISCORD_CLIENT_ID
-DISCORD_CLIENT_SECRET
-GOOGLE_CLIENT_ID
-GOOGLE_CLIENT_SECRET
-FACEBOOK_CLIENT_ID
-FACEBOOK_CLIENT_SECRET
-GITHUB_CLIENT_ID
-GITHUB_CLIENT_SECRET
-```
-
-  Maintainers:
-  
-  - [@mauriciabad](https://github.com/mauriciabad/)
-  
-  ### Backend server
-  
-  We use Vercel as the backend server:
-  
-  
-  GITHUB_CLIENT_SECRET: z.string(),
-
+- `DISCORD_CLIENT_ID, `DISCORD_CLIENT_SECRET`.
+- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`.
+- `FACEBOOK_CLIENT_ID`, `FACEBOOK_CLIENT_SECRET`.
+- `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`.
 Maintainers:
 
 - [@mauriciabad](https://github.com/mauriciabad/)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,32 @@ npx prisma studio
 
 To connect to the database and authentication providers, you need a `.env` file in the root. This file is private and the only way to get it is to ask someone that has it to send it to you, in this case, the maintainers of the project.
 
+For authenication to work, at least one set of client ID and client secret needs to be set.
+
+FIXME Add to schema and validation logic.
+
+```
+DISCORD_CLIENT_ID
+DISCORD_CLIENT_SECRET
+GOOGLE_CLIENT_ID
+GOOGLE_CLIENT_SECRET
+FACEBOOK_CLIENT_ID
+FACEBOOK_CLIENT_SECRET
+GITHUB_CLIENT_ID
+GITHUB_CLIENT_SECRET
+```
+
+  Maintainers:
+  
+  - [@mauriciabad](https://github.com/mauriciabad/)
+  
+  ### Backend server
+  
+  We use Vercel as the backend server:
+  
+  
+  GITHUB_CLIENT_SECRET: z.string(),
+
 Maintainers:
 
 - [@mauriciabad](https://github.com/mauriciabad/)

--- a/src/env/schema.mjs
+++ b/src/env/schema.mjs
@@ -19,14 +19,14 @@ export const serverSchema = z.object({
     // VERCEL_URL doesn't include `https` so it cant be validated as a URL
     process.env.VERCEL ? z.string() : z.string().url()
   ),
-  DISCORD_CLIENT_ID: z.string(),
-  DISCORD_CLIENT_SECRET: z.string(),
-  GOOGLE_CLIENT_ID: z.string(),
-  GOOGLE_CLIENT_SECRET: z.string(),
-  FACEBOOK_CLIENT_ID: z.string(),
-  FACEBOOK_CLIENT_SECRET: z.string(),
-  GITHUB_CLIENT_ID: z.string(),
-  GITHUB_CLIENT_SECRET: z.string(),
+  DISCORD_CLIENT_ID: z.optional(z.string()),
+  DISCORD_CLIENT_SECRET: z.optional(z.string()),
+  GOOGLE_CLIENT_ID: z.optional(z.string()),
+  GOOGLE_CLIENT_SECRET: z.optional(z.string()),
+  FACEBOOK_CLIENT_ID: z.optional(z.string()),
+  FACEBOOK_CLIENT_SECRET: z.optional(z.string()),
+  GITHUB_CLIENT_ID: z.optional(z.string()),
+  GITHUB_CLIENT_SECRET: z.optional(z.string()),
 })
 
 /**

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -11,6 +11,49 @@ import { env } from '../../../env/server.mjs'
 import { prisma } from '../../../server/db/client'
 import brandImage from '../../../assets/brand-image-round-corners.png'
 
+let providers = []
+if (env.GITHUB_CLIENT_ID && env.GITHUB_CLIENT_SECRET) {
+  providers.push(
+    GitHubProvider({
+      clientId: env.GITHUB_CLIENT_ID,
+      clientSecret: env.GITHUB_CLIENT_SECRET,
+    })
+  )
+}
+
+if (env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET) {
+  providers.push(
+    GoogleProvider({
+      clientId: env.GOOGLE_CLIENT_ID,
+      clientSecret: env.GOOGLE_CLIENT_SECRET,
+    }),
+  )
+}
+
+if (env.FACEBOOK_CLIENT_ID && env.FACEBOOK_CLIENT_SECRET) {
+  providers.push(
+    FacebookProvider({
+      clientId: env.FACEBOOK_CLIENT_ID,
+      clientSecret: env.FACEBOOK_CLIENT_SECRET,
+    }),
+  )
+  providers.push(
+    InstagramProvider({
+      clientId: process.env.FACEBOOK_CLIENT_ID,
+      clientSecret: process.env.FACEBOOK_CLIENT_SECRET,
+    }),
+  )
+}
+
+if (env.DISCORD_CLIENT_ID && env.DISCORD_CLIENT_SECRET) {
+  providers.push(
+    DiscordProvider({
+      clientId: env.DISCORD_CLIENT_ID,
+      clientSecret: env.DISCORD_CLIENT_SECRET,
+    }),
+  )
+}
+
 export const authOptions: NextAuthOptions = {
   // Include user.id on session
   callbacks: {
@@ -33,28 +76,7 @@ export const authOptions: NextAuthOptions = {
   },
   // Configure one or more authentication providers
   adapter: PrismaAdapter(prisma),
-  providers: [
-    GoogleProvider({
-      clientId: env.GOOGLE_CLIENT_ID,
-      clientSecret: env.GOOGLE_CLIENT_SECRET,
-    }),
-    FacebookProvider({
-      clientId: env.FACEBOOK_CLIENT_ID,
-      clientSecret: env.FACEBOOK_CLIENT_SECRET,
-    }),
-    InstagramProvider({
-      clientId: process.env.FACEBOOK_CLIENT_ID,
-      clientSecret: process.env.FACEBOOK_CLIENT_SECRET,
-    }),
-    DiscordProvider({
-      clientId: env.DISCORD_CLIENT_ID,
-      clientSecret: env.DISCORD_CLIENT_SECRET,
-    }),
-    GitHubProvider({
-      clientId: env.GITHUB_CLIENT_ID,
-      clientSecret: env.GITHUB_CLIENT_SECRET,
-    }),
-  ],
+  providers: providers,
 }
 
 export default NextAuth(authOptions)


### PR DESCRIPTION
I’ve made the OAuth providers optional by checking if their environment variables are set.

I’d like to update the environment variable validation stricter by adding a check that at least one OAuth provider is setup.

I need to test these changes actually work.